### PR TITLE
Add separate build targets for each platform to root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,9 @@ all:
 
 clean:
 	@for dir in $(SUBDIRS); do $(MAKE) clean -C $$dir; done
+
+nds:
+	$(MAKE) -C 3ds
+
+nx:
+	$(MAKE) -C switch

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ all:
 clean:
 	@for dir in $(SUBDIRS); do $(MAKE) clean -C $$dir; done
 
-nds:
+3ds:
 	$(MAKE) -C 3ds
 
-nx:
+switch:
 	$(MAKE) -C switch
+
+.PHONY: $(SUBDIRS)


### PR DESCRIPTION
Allows independent building for each platform via either `make 3ds` or `make switch`.