### PR TITLE
Restore applet mode

### DIFF
--- a/switch/source/util.cpp
+++ b/switch/source/util.cpp
@@ -46,11 +46,11 @@ Result servicesInit(void)
 {
     Logger::getInstance().log(Logger::INFO, "Starting Checkpoint loading...");
 
-    int appletType = (int)appletGetAppletType();
-    if (appletType != AppletType_Application) {
-        Logger::getInstance().log(Logger::ERROR, "Please run Checkpoint under Atmosphére title takeover. AppletType is %d.", appletType);
-        return -1;
-    }
+    // int appletType = (int)appletGetAppletType();
+    // if (appletType != AppletType_Application) {
+    //     Logger::getInstance().log(Logger::ERROR, "Please run Checkpoint under Atmosphére title takeover. AppletType is %d.", appletType);
+    //     return -1;
+    // }
 
     Result socinit = 0;
     if ((socinit = socketInitializeDefault()) == 0) {


### PR DESCRIPTION
Please find a way to make the attached build crash while using Checkpoint under album or general system applet mode. If you do that, it would be much appreciated
[Checkpoint.zip](https://github.com/FlagBrew/Checkpoint/files/3592375/Checkpoint.zip)

