### PR TITLE
Fix building on latest libnx and Update README.md (#building)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ devkitARM and devkitA64 are required to compile Checkpoint for 3DS and Switch, r
 
 ### 3DS version
 
-`dkp-pacman -S libctru citro3d citro2d`
+`dkp-pacman -S libctru citro3d citro2d 3ds-bzip2`
 
 ### Switch version
 

--- a/switch/source/title.cpp
+++ b/switch/source/title.cpp
@@ -263,7 +263,7 @@ void loadTitles(void)
 
                         // load play statistics
                         PdmPlayStatistics stats;
-                        res = pdmqryQueryPlayStatisticsByApplicationIdAndUserAccountId(tid, uid, &stats);
+                        res = pdmqryQueryPlayStatisticsByApplicationIdAndUserAccountId(tid, uid, false, &stats);
                         if (R_SUCCEEDED(res)) {
                             title.playTimeMinutes(stats.playtimeMinutes);
                             title.lastPlayedTimestamp(stats.last_timestampUser);

--- a/switch/source/util.cpp
+++ b/switch/source/util.cpp
@@ -70,7 +70,7 @@ Result servicesInit(void)
 
     romfsInit();
 
-    if (R_FAILED(res = plInitialize())) {
+    if (R_FAILED(res = plInitialize(PlServiceType_User))) {
         Logger::getInstance().log(Logger::ERROR, "plInitialize failed. Result code 0x%08lX.", res);
         return res;
     }


### PR DESCRIPTION
3ds-bzip2 is a required install for building. 2 fixes to build with latest libnx.