### PR TITLE
Update 3DS dependencies to include 'tex3ds' and '3ds-bzip2'

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ devkitARM and devkitA64 are required to compile Checkpoint for 3DS and Switch, r
 
 ### 3DS version
 
-`dkp-pacman -S libctru citro3d citro2d tex3ds`
+`dkp-pacman -S libctru citro3d citro2d tex3ds 3ds-bzip2`
 
 ### Switch version
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ devkitARM and devkitA64 are required to compile Checkpoint for 3DS and Switch, r
 
 ### 3DS version
 
-`dkp-pacman -S libctru citro3d citro2d`
+`dkp-pacman -S libctru citro3d citro2d tex3ds`
 
 ### Switch version
 


### PR DESCRIPTION
This was required in order for `make` to work.

I was seeing this issue:

```
mrhappyasthma$ make 3ds
sprites.t3s
make[2]: tex3ds: No such file or directory
make[2]: *** [sprites.h] Error 1
make[1]: *** [all] Error 2
make: *** [3ds] Error 2
```

and

```
Checkpoint/3ds/include/cheatmanager.hpp:34:10: fatal error: bzlib.h: No such file or directory
   34 | #include <bzlib.h>
      |          ^~~~~~~~~
```