### PR TITLE
Improved display of titles with accented letters

### DIFF
--- a/switch/source/title.cpp
+++ b/switch/source/title.cpp
@@ -55,12 +55,14 @@ void Title::init(u8 saveDataType, u64 id, AccountUid userID, const std::string& 
     mUserName     = Account::username(userID);
     mAuthor       = author;
     mName         = name;
-    mSafeName     = StringUtils::containsInvalidChar(name) ? StringUtils::format("0x%016llX", mId) : StringUtils::removeForbiddenCharacters(name);
-    mPath         = "sdmc:/switch/Checkpoint/saves/" + StringUtils::format("0x%016llX", mId) + " " + mSafeName;
 
     std::string aname = StringUtils::removeAccents(mName);
+    mSafeName     = StringUtils::containsInvalidChar(aname) ? StringUtils::format("0x%016llX", mId) : StringUtils::removeForbiddenCharacters(aname);
+    mPath         = "sdmc:/switch/Checkpoint/saves/" + StringUtils::format("0x%016llX", mId) + " " + mSafeName;
+
+    
     size_t pos        = aname.rfind(":");
-    mDisplayName      = std::make_pair(name, "");
+    mDisplayName      = std::make_pair(aname, "");
     if (pos != std::string::npos) {
         std::string name1 = aname.substr(0, pos);
         std::string name2 = aname.substr(pos + 1);


### PR DESCRIPTION
This improves the display of titles with accented letters, e. g. all the Pokémon games.

With the original code the game Pokémon Sword is displayed as Pok mon Sword and saves are stored in the folder 0x0100ABF008968000 0x0100ABF008968000 

With my changes the game is displayed as "Pokemon Sword" in the app itself and the saves are stored in the folder
0x0100ABF008968000 Pokemon Sword

That makes the save files a lot more convenient to manage, especially if you've got more Pokémon games installed as you won't have to go by the title IDs anymore.