### PR TITLE
fix for compilation with libnx v3.0.0

### DIFF
--- a/switch/source/title.cpp
+++ b/switch/source/title.cpp
@@ -263,7 +263,7 @@ void loadTitles(void)
 
                         // load play statistics
                         PdmPlayStatistics stats;
-                        res = pdmqryQueryPlayStatisticsByApplicationIdAndUserAccountId(tid, uid, false, &stats);
+                        res = pdmqryQueryPlayStatisticsByApplicationIdAndUserAccountId(tid, uid, &stats);
                         if (R_SUCCEEDED(res)) {
                             title.playTimeMinutes(stats.playtimeMinutes);
                             title.lastPlayedTimestamp(stats.last_timestampUser);

--- a/switch/source/util.cpp
+++ b/switch/source/util.cpp
@@ -70,7 +70,7 @@ Result servicesInit(void)
 
     romfsInit();
 
-    if (R_FAILED(res = plInitialize(PlServiceType_User))) {
+    if (R_FAILED(res = plInitialize())) {
         Logger::getInstance().log(Logger::ERROR, "plInitialize failed. Result code 0x%08lX.", res);
         return res;
     }


### PR DESCRIPTION
This fixes for compilation with libnx 3.0.0; building with libnx at least that new allows Checkpoint to function on 12.0.0/Atmosphere 0.19.0.