### PR TITLE
Update sha256 macro definition to avoid collision with libnx.

### DIFF
--- a/3ds/source/title.cpp
+++ b/3ds/source/title.cpp
@@ -500,33 +500,33 @@ void loadTitles(bool forceRefresh)
 
     bool optimizedLoad = false;
 
-    u8 hash[SHA256_BLOCK_SIZE];
+    u8 hash[SHA256_HASH_SIZE];
     calculateTitleDBHash(hash);
 
     std::u16string titlesHashPath = StringUtils::UTF8toUTF16("/3ds/Checkpoint/titles.sha");
     if (!io::fileExists(Archive::sdmc(), titlesHashPath) || !io::fileExists(Archive::sdmc(), savecachePath) ||
         !io::fileExists(Archive::sdmc(), extdatacachePath)) {
         // create title list sha256 hash file if it doesn't exist in the working directory
-        FSStream output(Archive::sdmc(), titlesHashPath, FS_OPEN_WRITE, SHA256_BLOCK_SIZE);
-        output.write(hash, SHA256_BLOCK_SIZE);
+        FSStream output(Archive::sdmc(), titlesHashPath, FS_OPEN_WRITE, SHA256_HASH_SIZE);
+        output.write(hash, SHA256_HASH_SIZE);
         output.close();
     }
     else {
         // compare current hash with the previous hash
         FSStream input(Archive::sdmc(), titlesHashPath, FS_OPEN_READ);
-        if (input.good() && input.size() == SHA256_BLOCK_SIZE) {
+        if (input.good() && input.size() == SHA256_HASH_SIZE) {
             u8* buf = new u8[input.size()];
             input.read(buf, input.size());
             input.close();
 
-            if (memcmp(hash, buf, SHA256_BLOCK_SIZE) == 0) {
+            if (memcmp(hash, buf, SHA256_HASH_SIZE) == 0) {
                 // hash matches
                 optimizedLoad = true;
             }
             else {
                 FSUSER_DeleteFile(Archive::sdmc(), fsMakePath(PATH_UTF16, titlesHashPath.data()));
-                FSStream output(Archive::sdmc(), titlesHashPath, FS_OPEN_WRITE, SHA256_BLOCK_SIZE);
-                output.write(hash, SHA256_BLOCK_SIZE);
+                FSStream output(Archive::sdmc(), titlesHashPath, FS_OPEN_WRITE, SHA256_HASH_SIZE);
+                output.write(hash, SHA256_HASH_SIZE);
                 output.close();
             }
 

--- a/3rd-party/sha256/sha256.h
+++ b/3rd-party/sha256/sha256.h
@@ -13,7 +13,9 @@
 #include <stddef.h>
 
 /****************************** MACROS ******************************/
-#define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
+#ifndef SHA256_HASH_SIZE
+#define SHA256_HASH_SIZE 32            // SHA256 outputs a 32 byte digest
+#endif
 
 /**************************** DATA TYPES ****************************/
 typedef unsigned char BYTE;             // 8-bit byte


### PR DESCRIPTION
libnx has its own sha256 implementation, and it uses `SHA256_BLOCK_SIZE`
to represent the full block size (64 bytes). This was causing an issue
when we try to redefine it using the hash size (32 bytes).

libnx definition: https://github.com/switchbrew/libnx/blob/c5a9a909a91657a9818a3b7e18c9b91ff0cbb6e3/nx/include/switch/crypto/sha256.h#L15

I updated the macro to reuse the same naming as libnx `SHA256_HASH_SIZE`
and to avoid redefining it if it already exists.

This fixes the following warning (if including "sha256.h" in the Switch
build):

    warning: "SHA256_BLOCK_SIZE" redefined