### PR TITLE
Silence unused parameter warning in configuration.cpp.

### DIFF
--- a/switch/source/configuration.cpp
+++ b/switch/source/configuration.cpp
@@ -33,6 +33,7 @@ static const char* s_http_port = "8000";
 
 static void handle_populate(struct mg_connection* nc, struct http_message* hm)
 {
+    (void)hm;
     // populate gets called at startup, assume a new connection has been started
     blinkLed(2);
 


### PR DESCRIPTION
M:/GitHub/Checkpoint/switch/source/configuration.cpp: In function 'void handle_populate(mg_connection*, http_message*)':
M:/GitHub/Checkpoint/switch/source/configuration.cpp:34:76: warning: unused parameter 'hm' [-Wunused-parameter]
   34 | static void handle_populate(struct mg_connection* nc, struct http_message* hm)
      |                                                       ~~~~~~~~~~~~~~~~~~~~~^~